### PR TITLE
Fix Rellax usage cleanup

### DIFF
--- a/src/components/about/About.jsx
+++ b/src/components/about/About.jsx
@@ -9,7 +9,10 @@ export const About = () => {
   const isBigScreen = useMediaQuery({ query: '(max-width: 1200px)' });
   const isHugeScreen = useMediaQuery({ query: '(min-width: 1660px)' });
   useEffect(() => {
-    new Rellax('.rellax');
+    const rellax = new Rellax('.rellax');
+    return () => {
+      rellax.destroy();
+    };
   }, []);
 
   return (

--- a/src/components/projects/Projects.jsx
+++ b/src/components/projects/Projects.jsx
@@ -46,7 +46,7 @@ export const Projects = () => {
     // });
 
     // instance.start();
-    new Rellax('.slow', {
+    const slow = new Rellax('.slow', {
       speed: 0,
       center: false,
       //   wrapper: null,
@@ -54,7 +54,7 @@ export const Projects = () => {
       vertical: true,
       horizontal: false,
     });
-    new Rellax('.fast', {
+    const fast = new Rellax('.fast', {
       speed: 10,
       center: false,
       //   wrapper: null,
@@ -62,6 +62,10 @@ export const Projects = () => {
       vertical: true,
       horizontal: false,
     });
+    return () => {
+      slow.destroy();
+      fast.destroy();
+    };
     // var rellax = new Rellax('.rellax');
   }, []);
   return (

--- a/src/components/resume/Resume.jsx
+++ b/src/components/resume/Resume.jsx
@@ -3,14 +3,17 @@ import Rellax from 'rellax';
 
 export const Resume = () => {
   useEffect(() => {
-    new Rellax('.fast', {
+    const rellax = new Rellax('.fast', {
       speed: 10,
       center: false,
       //   wrapper: null,
       round: true,
       vertical: true,
-      horizontal: false
+      horizontal: false,
     });
+    return () => {
+      rellax.destroy();
+    };
   }, []);
   return <Fragment></Fragment>;
 };


### PR DESCRIPTION
## Summary
- keep the Rellax instance when created
- destroy each Rellax instance in an effect cleanup

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6844a3f2f2cc8323a508169d36ae8013